### PR TITLE
Added overall cancel command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Pipfile.lock
 story_graph.dot
 
 endpoints.yml
+results/

--- a/actions/cancel_command_actions/action_cancel_commands.py
+++ b/actions/cancel_command_actions/action_cancel_commands.py
@@ -1,0 +1,19 @@
+from typing import Any, Text, Dict, List
+
+from rasa_sdk.events import AllSlotsReset, ActiveLoop
+from rasa_sdk import Action, Tracker
+from rasa_sdk.executor import CollectingDispatcher
+
+
+class ActionCancelCommands(Action):
+    """This is the action that is called when the user says "cancel"."""
+
+    @staticmethod
+    def name(**kwargs) -> Text:
+        return "action_cancel_commands"
+
+    def run(self, dispatcher: CollectingDispatcher, tracker: Tracker, domain: Dict[Text, Any], **kwargs) -> List[
+        Dict[Text, Any]
+    ]:
+        dispatcher.utter_message("Okay, cancelling running commands!")
+        return [AllSlotsReset(), ActiveLoop(None)]

--- a/actions/car_selection_actions/action_ask_car_number.py
+++ b/actions/car_selection_actions/action_ask_car_number.py
@@ -65,6 +65,12 @@ class ActionAskCarNumber(Action):
                         "action": response.action.as_dict(),
                         "data": response.data
                     })
+            else:
+                # return a message and deactive the form
+                print(f"{self.name()}: User is not on car selection or dashboard screen")
+                dispatcher.utter_message(
+                    text="User is not on car selection or dashboard screen")
+                return [ActiveLoop(None), SlotSet('car_number', None)]
         # else:
             # return a message and deactive the form
             # print(f"{self.name()}: {metadata['type']} is not CAR_SELECTION")

--- a/actions/car_selection_actions/validate_car_selection_form.py
+++ b/actions/car_selection_actions/validate_car_selection_form.py
@@ -53,7 +53,7 @@ class ValidateCarSelectionForm(FormValidationAction):
             # if s
             if slot_value.lower() not in ALLOWED_CAR_NUMBER:
                 response = car_utils.return_response(
-                    "Please specify a correct number that is one, two or three")
+                    "Please specify a correct number that is first, second, or third")
                 dispatcher.utter_message(json_message={
                     "query": response.query,
                     "reply": response.reply,
@@ -78,7 +78,7 @@ class ValidateCarSelectionForm(FormValidationAction):
                 return {"car_number": None, "next_car": True, "previous_car": False,
                         "select_car_iteration": return_select_car_iteration}
             if slot_value.lower() == "previous" and select_car_iteration == 0:
-                response = car_utils.return_response(available_message)
+                response = car_utils.return_response("You are on the first list, you can't go previous")
                 dispatcher.utter_message(json_message={
                     "query": response.query,
                     "reply": response.reply,
@@ -115,11 +115,6 @@ class ValidateCarSelectionForm(FormValidationAction):
         """Validate `car_number` value."""
 
         print("Slot Value", slot_value)
-        intent = None
-        try:
-            intent = tracker.latest_message['intent'].get('name')
-        except KeyError:
-            print(f"No intent, something went wrong, error:{Exception}")
 
         select_car_iteration = tracker.get_slot("select_car_iteration")
         metadata = tracker.latest_message.get("metadata")
@@ -136,7 +131,7 @@ class ValidateCarSelectionForm(FormValidationAction):
                 response = car_utils.return_response(available_message)
                 dispatcher.utter_message(json_message={
                     "query": response.query,
-                    "reply": response.reply,
+                    "reply": f"Okay reverting the last decision, {response.reply}",
                     "action": response.action.as_dict(),
                     "data": response.data
                 })
@@ -181,13 +176,10 @@ class ValidateCarSelectionForm(FormValidationAction):
 
         # TODO: new function -> reset only car selection related slots
         if slot_value == "third" and len(available_cars) >= 3:
-            # dispatcher.utter_message(text=f"{available_cars[2]} car is available")
             return {"car_number": "third", "car_name": available_cars[2]}
         if slot_value == "second" and len(available_cars) >= 2:
-            # dispatcher.utter_message(text=f"{available_cars[1]} car is available")
             return {"car_number": "second", "car_name": available_cars[1]}
         if slot_value == "first" and len(available_cars) >= 1:
-            # dispatcher.utter_message(text=f"{available_cars[0]} car is available")
             return {"car_number": "first", "car_name": available_cars[0]}
 
         print(f"{self.name()}: Something went wrong with validating car selection and assigning 'car_name' slot.")

--- a/actions/start_recording_actions/action_start_recording.py
+++ b/actions/start_recording_actions/action_start_recording.py
@@ -158,14 +158,14 @@ class ActionStartRecording(Action):
                         text="Wrong Recording state, Something went wrong!")
                     return [SlotSet("recording_start_query", False)]
             else:
-                reply = "Recording is already running! Navigating to recording screen"
+                reply = "User is not on dashboard screen, Please navigate to Dashboard screen and ask start recording again."
                 nav_to_recording_screen(dispatcher, message, reply,  intent)
                 return [SlotSet("recording_start_query", False)]
         else:
-            print(f"{self.name()}: No Recording going on!")
-            dispatcher.utter_message(
-                text="There is currently no Recording going on")
-            return []
+            print(f"{self.name()}: Recording already going on!")
+            reply = "Recording is already running! Navigating to recording screen"
+            nav_to_recording_screen(dispatcher, message, reply,  intent)
+            return [SlotSet("recording_start_query", False)]
         # else:
         #     print(f" {self.name()}: {metadata['type']} is not RECORDING")
         #     dispatcher.utter_message(

--- a/data/nlu/nlu.yml
+++ b/data/nlu/nlu.yml
@@ -175,6 +175,20 @@ nlu:
       - choose [second](car_selection_number) car
       - choose [third](car_selection_number) car please
 
+  - intent: overall_cancel_command
+    examples: |
+      - cancel
+      - cancel it
+      - cancel everything
+      - cancel all
+      - cancel start recording
+      - cancel stop recording
+      - cancel select car
+      - cancel choose car
+      - can you cancel this
+      - please cancel command
+      - enviroBot cancel this
+
   - synonym: select
     examples: |
       - select

--- a/data/rules.yml
+++ b/data/rules.yml
@@ -13,6 +13,8 @@ rules:
       - action: utter_iamabot
 
   - rule: Run a followup start action anytime the user affirms
+    condition:
+      - active_loop: null
     steps:
       - intent: affirm
       - action: action_followup
@@ -52,4 +54,12 @@ rules:
       - active_loop: null
       - slot_was_set:
           - requested_slot: null
+      - action: action_car_selection
+
+  - rule: Select a car whenever user affirms in car selection form
+    condition:
+      - active_loop: car_selection_form
+    steps:
+      - slot_was_set:
+          - car_verification: yes
       - action: action_car_selection

--- a/data/rules.yml
+++ b/data/rules.yml
@@ -63,3 +63,8 @@ rules:
       - slot_was_set:
           - car_verification: yes
       - action: action_car_selection
+
+  - rule: Run `cancel_commands` action whenever `overall_cancel_command` intent is triggered
+    steps:
+      - intent: overall_cancel_command
+      - action: action_cancel_commands

--- a/domain.yml
+++ b/domain.yml
@@ -24,6 +24,7 @@ actions:
   - action_ask_car_verification
   - action_car_selection
   - action_followup
+  - action_cancel_commands
 
 forms:
   car_selection_form:
@@ -88,7 +89,6 @@ slots:
             requested_slot: car_number
   car_name:
     type: text
-    influence_conversation: true
     mappings:
       - type: custom
         conditions:
@@ -106,7 +106,6 @@ slots:
             requested_slot: select_car_iteration
   next_car:
     type: bool
-    influence_conversation: true
     mappings:
       - type: custom
         conditions:
@@ -114,7 +113,6 @@ slots:
             requested_slot: next_car
   previous_car:
     type: bool
-    influence_conversation: true
     mappings:
       - type: custom
         conditions:


### PR DESCRIPTION
## Description: 

Overall cancel command will stop ongoing voice commands and let the user start another workflow if asked.

## Why Needed:

### Unhappy workflow
**User**: Select a car (Backend: Start car selection form and keep checking pre-requisites and if fulfilled select a car)
**Bot**: which one do you want to select? 1? 2? 3? (This is a custom message, just added here to decrease complexity) 
**User**: Start Recording
**Bot**: Wrong request
**User**: Please start recording
**Bot**: Wrong request

User experience: 😞  

Bot persists to have memory for a long time which makes it hard for the user to start another workflow. While this can be easily handled by adding an edge story to handle the start recording while car selection is happening. But it becomes hard to maintain this for every other command.

### Happy workflow
**User**: Select a car (Backend: Start car selection form and keep checking pre-requisites and if fulfilled select a car)
**Bot**: which one do you want to select? 1? 2? 3? (This is a custom message, just added here to decrease complexity) 
**User**: Cancel car selection
**Bot**: Okay, canceling running commands!
**User**: Please start recording
**Bot**: (start recording action starts)

User experience: 😄

## Action points:

- [x] Added training data
- [x] Added stories
- [x] Added rules
- [x] Cancel command custom action
- [x] Tested
 

## Screen recording:

I will add it soon!