### PR TITLE
Code corrections for RTTG CI Workflow

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,5 @@
 recipe: default.v1
+assistant_id: envirobot
 language: en
 
 pipeline:

--- a/domain.yml
+++ b/domain.yml
@@ -30,6 +30,10 @@ forms:
     required_slots:
       - car_number
       - car_verification
+      - car_name
+      - select_car_iteration
+      - next_car
+      - previous_car
 
 slots:
   is_dashboard_fragment:


### PR DESCRIPTION
## Code corrections for RTTG CI Workflow

Mentions #3 

The corrections in this PR are based on the response of `rasa train` command. These corrections are mandatory for the [Rasa-Train-Test-GHA (RTTG)](https://github.com/RasaHQ/rasa-train-test-gha) CI Workflow to work as `rasa train` is one of the preliminary steps in the action.

![Screenshot (1067)](https://github.com/enviroCar/envirocar-rasa-bot/assets/33064931/22f08027-eaf2-46ad-b486-3642ced9d0aa)
